### PR TITLE
Added missing annotations sections in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,15 +124,16 @@ Artifact details are correlated to Backstage entities using an annotation added 
 
 ```yaml
   metadata:
-    # -- required values --
-    jfrog.com/artifactory-artifact: 'artifact-name'
-    jfrog.com/artifactory-repo: 'maven-local'
+    annotations:
+      # -- required values --
+      jfrog.com/artifactory-artifact: 'artifact-name'
+      jfrog.com/artifactory-repo: 'maven-local'
 
-    jfrog.com/artifactory-group: 'com.mycompany' # optional string - can be blank for pypi, necessary for Maven repos
+      jfrog.com/artifactory-group: 'com.mycompany' # optional string - can be blank for pypi, necessary for Maven repos
 
-    # -- optional values --
-    jfrog.com/artifactory-scope: 'compile' # optional string, one of these [compile, test,provided,runtime,classpath,optional]
-    jfrog.com/artifactory-packaging: 'aar' #optional string, eg. `aar` 
+      # -- optional values --
+      jfrog.com/artifactory-scope: 'compile' # optional string, one of these [compile, test,provided,runtime,classpath,optional]
+      jfrog.com/artifactory-packaging: 'aar' #optional string, eg. `aar` 
 
 ```
 
@@ -142,9 +143,10 @@ you navigate to the entity page where it's included.
 For a docker image you define repository and artifact name. Both formats are supported:
 ```yaml
   metadata:
-    # -- required values --
-    jfrog.com/artifactory-artifact: 'docker.mydomain.com/mygroup/my/artifact-name' # or simply 'mygroup/my/artifact-name' 
-    jfrog.com/artifactory-repo: 'docker-local'
+    annotations:
+      # -- required values --
+      jfrog.com/artifactory-artifact: 'docker.mydomain.com/mygroup/my/artifact-name' # or simply 'mygroup/my/artifact-name' 
+      jfrog.com/artifactory-repo: 'docker-local'
 ```
 
 ![Demo](./doc/dockerfile.gif)


### PR DESCRIPTION
The take effect the annotations for the plugin need to be added below metadata.annotations.